### PR TITLE
Omit comments on .env files

### DIFF
--- a/gen-env-types.js
+++ b/gen-env-types.js
@@ -98,19 +98,24 @@ const envString = readFileSync(cliConfig.envPath, {
   encoding: "utf8",
 });
 
-function writeEnvTypes(envString, path) {
-  writeFileSync(
-    path,
-    `declare namespace NodeJS {
+function buildEnvTypes(envString){
+  return `
+declare namespace NodeJS {
   export interface ProcessEnv {
     ${envString
       .split("\n")
-      .filter((line) => line)
+      .filter((line) => line && !line.startsWith('#'))
       .map((x, i) => `${i ? "    " : ""}${x.split("=")[0]}: string;`)
       .join("\n")}
   }
 }
 `
+}
+
+function writeEnvTypes(envString, path) {
+  writeFileSync(
+    path,
+    buildEnvTypes(envString)
   );
 
   console.log("Wrote env types to: ", path);

--- a/gen-env-types.js
+++ b/gen-env-types.js
@@ -104,7 +104,7 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     ${envString
       .split("\n")
-      .filter((line) => line && !line.startsWith('#'))
+      .filter((line) => line && line.trim().indexOf('#') !== 0)
       .map((x, i) => `${i ? "    " : ""}${x.split("=")[0]}: string;`)
       .join("\n")}
   }


### PR DESCRIPTION
Addressing Issue #3 

- Remove lines on `.env` files that are comments
  - Preferred `.indexOf` for performance reasons based on [this](https://www.measurethat.net/Benchmarks/Show/4797/1/js-regex-vs-startswith-vs-indexof#latest_results_block)
- Extract into a specific function the generation of the string that creates types. This should help testability of the method when tests are added