### PR TITLE
Update gen-env-types.js

### DIFF
--- a/gen-env-types.js
+++ b/gen-env-types.js
@@ -98,24 +98,19 @@ const envString = readFileSync(cliConfig.envPath, {
   encoding: "utf8",
 });
 
-function buildEnvTypes(envString){
-  return `
-declare namespace NodeJS {
+function writeEnvTypes(envString, path) {
+  writeFileSync(
+    path,
+    `declare namespace NodeJS {
   export interface ProcessEnv {
     ${envString
       .split("\n")
-      .filter((line) => line && line.trim().indexOf('#') !== 0)
-      .map((x, i) => `${i ? "    " : ""}${x.split("=")[0]}: string;`)
+      .filter((line) => line.trim() && line.trim().indexOf("#") !== 0)
+      .map((x, i) => `${i ? "    ": ""}${x.trim().split("=")[0]}: string;`)
       .join("\n")}
   }
 }
 `
-}
-
-function writeEnvTypes(envString, path) {
-  writeFileSync(
-    path,
-    buildEnvTypes(envString)
   );
 
   console.log("Wrote env types to: ", path);


### PR DESCRIPTION
Fix: enable comments inside `.env` files and fixes some errors when comments have spaces in front