### PR TITLE
Change module customisation behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,22 @@ declare namespace NodeJS {
 
 Now `process.env.SESSION_SECRET` will autocomplete and be type-safe.
 
-If you want to generate a union instead of string type, add an inline comment to your `.env` file:
+## Customize
 
-```toml
-NODE_ENV=production # production | development
-
-# Also works with strings!
-NODE_ENV = "production" # production | development
-```
+`gen-env-types` respects changes made to generated files, meaning you can overwrite `.env.example` and `env.d.ts` values, this can be helpful if you want a union type:
 
 ```typescript
 declare namespace NodeJS {
   export interface ProcessEnv {
-    NODE_ENV: "production" | "development";
+    NODE_ENV: "development" | "production";
   }
 }
+```
+
+Or if you want to persist `.env.example` values:
+
+```toml
+PORT=3000
 ```
 
 ## Usage
@@ -50,7 +51,7 @@ npx gen-env-types path/to/.env
   -h, --help                  Show usage information
   -o, --types-output          Output name/path for types file | defaults to `env.d.ts`
   -e, --example-env-path      Path to save .env.example file
-  -r,  --rename-example-env   Custom name for .env example output file | defaults to `env.example` if omitted
+  -r, --rename-example-env    Custom name for .env example output file | defaults to `env.example` if omitted
 ```
 
 ## Examples with options


### PR DESCRIPTION
This PR changes the following:
- Remove `console.log` that was used for debugging
- Fixed an issue where `.env.example` was generated with original `.env` file values if it did not exist
- Instead of allowing inline comments for custom types (which was not valid), the script now keeps values that have been overwritten by the user, running the command again just adds new keys and defaults to `string` for values
- Updated README