### PR TITLE
Update code block highlighting language

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Takes your `.env` file as input
 
-```toml
+```sh
 SESSION_SECRET=asdjpfowqip
 STRIPE_ACCESS_TOKEN=qoi120wqe
 ```
@@ -34,7 +34,7 @@ declare namespace NodeJS {
 
 Or if you want to persist `.env.example` values:
 
-```toml
+```sh
 PORT=3000
 ```
 


### PR DESCRIPTION
It looks like highlighting `.env` in `toml` is not appropriate. So I use `sh` to highlight it according to `languages.yml` specified in `github/linguist`

https://github.com/github/linguist/blob/32ec19c013a7f81ffaeead25e6e8f9668c7ed574/lib/linguist/languages.yml#L5374-L5375

![image](https://user-images.githubusercontent.com/24631178/116805112-050e5400-ab5f-11eb-9237-e4af9b3d0a69.png)
