### PR TITLE
Modify generated types to be global

### DIFF
--- a/gen-env-types.js
+++ b/gen-env-types.js
@@ -126,27 +126,32 @@ function writeEnvTypes(path) {
   const existingModuleDeclaration =
     existsSync(path) && readFileSync(path, { encoding: "utf-8" });
 
-  const moduleDeclaration = `declare namespace NodeJS {
-  interface ProcessEnv {
-    ${Object.keys(parsedEnvString)
-      .map((key, i) => {
-        if (!existingModuleDeclaration) {
-          return `${i ? "    " : ""}${key}: string;`;
-        }
+  const moduleDeclaration = `declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      ${Object.keys(parsedEnvString)
+        .map((key, i) => {
+          if (!existingModuleDeclaration) {
+            return `${i ? "      " : ""}${key}: string;`;
+          }
 
-        const existingPropertySignature = existingModuleDeclaration
-          .split("\n")
-          .find((line) => line.includes(`${key}:`));
+          const existingPropertySignature = existingModuleDeclaration
+            .split("\n")
+            .find((line) => line.includes(`${key}:`));
 
-        if (!existingPropertySignature) {
-          return `${i ? "    " : ""}${key}: string;`;
-        }
+          if (!existingPropertySignature) {
+            return `${i ? "      " : ""}${key}: string;`;
+          }
 
-        return `${i ? "    " : ""}${existingPropertySignature.trim()}`;
-      })
-      .join("\n")}
+          return `${i ? "      " : ""}${existingPropertySignature.trim()}`;
+        })
+        .join("\n")}
+    }
   }
-}`;
+}
+
+export {}
+`;
 
   writeFileSync(path, moduleDeclaration);
 


### PR DESCRIPTION
Hi, I discovered the autocomplete doesn't seem to work except the configuration as mentioned here https://stackoverflow.com/a/53981706 is used i.e

```.ts
declare global {
  namespace NodeJS {
    interface ProcessEnv {
      GITHUB_AUTH_TOKEN: string;
      NODE_ENV: 'development' | 'production';
      PORT?: string;
      PWD: string;
    }
  }
}

// If this file has no import/export statements (i.e. is a script)
// convert it into a module by adding an empty export statement.
export {}
```

So this request contains the change to make the namespace global and exported as a module.