### PR TITLE
bugfix: wrong command param for --keep-comments

### DIFF
--- a/gen-env-types.js
+++ b/gen-env-types.js
@@ -87,7 +87,7 @@ const parseArgs = (args) => {
         cliConfig.exampleEnvOutput = args.shift();
         break;
       case "-k":
-      case "--keep-comment":
+      case "--keep-comments":
         cliConfig.keepComments = true;
         break;
       default: {


### PR DESCRIPTION
It turns out `--keep-comment` was missing `s`. 

Help says `--keep-comments` while the command was expecting `--keep-comment`.